### PR TITLE
Fix default opacity tick #4

### DIFF
--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -76,6 +76,7 @@ namespace Ruler
 
 			ResourceManager resources = new ResourceManager(typeof(MainForm));
 			this.Icon = ((Icon)(resources.GetObject("$this.Icon")));
+		    this.Opacity = rulerInfo.Opacity;
 
 			this.SetUpMenu();
 

--- a/Source/Ruler/RulerInfo.cs
+++ b/Source/Ruler/RulerInfo.cs
@@ -91,7 +91,7 @@ namespace Ruler
 
 			rulerInfo.Width = 400;
 			rulerInfo.Height = 75;
-			rulerInfo.Opacity = 0.65;
+			rulerInfo.Opacity = 0.60;
 			rulerInfo.ShowToolTip = false;
 			rulerInfo.IsLocked = false;
 			rulerInfo.IsVertical = false;


### PR DESCRIPTION
Made default menu opacity divisible by 10, and applied default opacity to MainForm before SetUpMenu() is called.