### PR TITLE
Fix quick moving resize

### DIFF
--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -121,7 +121,7 @@ namespace Ruler
 			this.CreateMenuItems(rulerInfo);
 
 			RulerInfo.CopyInto(rulerInfo, this);
-			this.previouslyLocked = this.isLocked ? true : false;
+			this.previouslyLocked = this.isLocked;
 
 			this.SetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint, true);
 		}
@@ -381,7 +381,7 @@ namespace Ruler
 
 		protected override void OnMouseDown(MouseEventArgs e)
 		{
-			this.isLocked = this.previouslyLocked ? true : false;
+			this.isLocked = this.previouslyLocked;
 			this.offset = new Point(Control.MousePosition.X - this.Location.X, Control.MousePosition.Y - this.Location.Y);
 			this.mouseDownPoint = Control.MousePosition;
 			this.mouseDownRect = this.ClientRectangle;

--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -31,6 +31,7 @@ namespace Ruler
 		private bool isVertical;
 		private bool isLocked;
 		private bool showToolTip;
+        private bool previouslyLocked;
 
 		private readonly RulerInfo initRulerInfo;
 
@@ -94,12 +95,14 @@ namespace Ruler
 
 		private void Init(RulerInfo rulerInfo)
 		{
-			// Set fields
-			this.toolTip = new ToolTip();
-			this.toolTip.AutoPopDelay = 10000;
-			this.toolTip.InitialDelay = 1;
+            // Set fields
+            this.toolTip = new ToolTip
+            {
+                AutoPopDelay = 10000,
+                InitialDelay = 1
+            };
 
-			this.resizeRegion = ResizeRegion.None;
+            this.resizeRegion = ResizeRegion.None;
 			this.resizeBorderWidth = 5;
 
 			// Form setup ------------------
@@ -118,6 +121,7 @@ namespace Ruler
 			this.CreateMenuItems(rulerInfo);
 
 			RulerInfo.CopyInto(rulerInfo, this);
+            this.previouslyLocked = this.isLocked ? true : false;
 
 			this.SetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint, true);
 		}
@@ -150,9 +154,11 @@ namespace Ruler
 
 			for (int i = 10; i <= 100; i += 10)
 			{
-				MenuItem subMenu = new MenuItem(i + "%", this.OpacityMenuHandler);
-				subMenu.Checked = i == rulerInfo.Opacity * 100;
-				opacityMenuItem.MenuItems.Add(subMenu);
+                MenuItem subMenu = new MenuItem(i + "%", this.OpacityMenuHandler)
+                {
+                    Checked = i == rulerInfo.Opacity * 100
+                };
+                opacityMenuItem.MenuItems.Add(subMenu);
 			}
 
 			// Build main context menu
@@ -298,6 +304,7 @@ namespace Ruler
 		private void LockResizeHandler(object sender, EventArgs e)
 		{
 			this.IsLocked = !this.IsLocked;
+            this.previouslyLocked = this.isLocked;
 		}
 
 		private void DuplicateHandler(object sender, EventArgs e)
@@ -374,6 +381,7 @@ namespace Ruler
 
 		protected override void OnMouseDown(MouseEventArgs e)
 		{
+            this.isLocked = this.previouslyLocked ? true : false;
 			this.offset = new Point(Control.MousePosition.X - this.Location.X, Control.MousePosition.Y - this.Location.Y);
 			this.mouseDownPoint = Control.MousePosition;
 			this.mouseDownRect = this.ClientRectangle;
@@ -414,6 +422,7 @@ namespace Ruler
 			}
 			else
 			{
+                this.isLocked = true;
 				this.Cursor = Cursors.Default;
 
 				if (e.Button == MouseButtons.Left)

--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -31,7 +31,7 @@ namespace Ruler
 		private bool isVertical;
 		private bool isLocked;
 		private bool showToolTip;
-        private bool previouslyLocked;
+		private bool previouslyLocked;
 
 		private readonly RulerInfo initRulerInfo;
 
@@ -95,14 +95,14 @@ namespace Ruler
 
 		private void Init(RulerInfo rulerInfo)
 		{
-            // Set fields
-            this.toolTip = new ToolTip
-            {
-                AutoPopDelay = 10000,
-                InitialDelay = 1
-            };
+			// Set fields
+			this.toolTip = new ToolTip
+			{
+				AutoPopDelay = 10000,
+				InitialDelay = 1
+			};
 
-            this.resizeRegion = ResizeRegion.None;
+			this.resizeRegion = ResizeRegion.None;
 			this.resizeBorderWidth = 5;
 
 			// Form setup ------------------
@@ -121,7 +121,7 @@ namespace Ruler
 			this.CreateMenuItems(rulerInfo);
 
 			RulerInfo.CopyInto(rulerInfo, this);
-            this.previouslyLocked = this.isLocked ? true : false;
+			this.previouslyLocked = this.isLocked ? true : false;
 
 			this.SetStyle(ControlStyles.DoubleBuffer | ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint, true);
 		}
@@ -154,11 +154,11 @@ namespace Ruler
 
 			for (int i = 10; i <= 100; i += 10)
 			{
-                MenuItem subMenu = new MenuItem(i + "%", this.OpacityMenuHandler)
-                {
-                    Checked = i == rulerInfo.Opacity * 100
-                };
-                opacityMenuItem.MenuItems.Add(subMenu);
+				MenuItem subMenu = new MenuItem(i + "%", this.OpacityMenuHandler)
+				{
+					Checked = i == rulerInfo.Opacity * 100
+				};
+				opacityMenuItem.MenuItems.Add(subMenu);
 			}
 
 			// Build main context menu
@@ -304,7 +304,7 @@ namespace Ruler
 		private void LockResizeHandler(object sender, EventArgs e)
 		{
 			this.IsLocked = !this.IsLocked;
-            this.previouslyLocked = this.isLocked;
+			this.previouslyLocked = this.isLocked;
 		}
 
 		private void DuplicateHandler(object sender, EventArgs e)
@@ -381,7 +381,7 @@ namespace Ruler
 
 		protected override void OnMouseDown(MouseEventArgs e)
 		{
-            this.isLocked = this.previouslyLocked ? true : false;
+			this.isLocked = this.previouslyLocked ? true : false;
 			this.offset = new Point(Control.MousePosition.X - this.Location.X, Control.MousePosition.Y - this.Location.Y);
 			this.mouseDownPoint = Control.MousePosition;
 			this.mouseDownRect = this.ClientRectangle;
@@ -422,7 +422,7 @@ namespace Ruler
 			}
 			else
 			{
-                this.isLocked = true;
+				this.isLocked = true;
 				this.Cursor = Cursors.Default;
 
 				if (e.Button == MouseButtons.Left)


### PR DESCRIPTION
This fixes #5 

No C# compiler warnings or errors Visual Studios 2017
No Style Cop Issues used style cop from contributors guide
Simplified tooltip initialization Visual Studios stated object initialization could be improved
Simplified Sub Opacity MenuItems as Visual Studios Stated object initialization could be improved