### PR TITLE
Make Ctrl/Shift more intuitive - Ctrl=resize Shift=smallStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ If you want to contribute to project, please follow the rules:
 ### Ruler shortcuts:
 
 - **Space** and **Double click**: will toggle direction of Ruler 
-- **Arrow keys**: move Ruler
-- **Ctrl** + **Shift** + **Arrow keys**: resize Ruler
+- **Arrow keys**: move Ruler (+ **Shift** for small step)
+- **Ctrl** + **Arrow keys**: resize Ruler (+ **Shift** for small step)
 
 ### Command line parameters (optional):
 In current implementation, you can either not use parameters (just start app) or use all parameters (you cannot used parameters selectively).

--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -474,76 +474,50 @@ namespace Ruler
 
 		private void HandleMoveResizeKeystroke(KeyEventArgs e)
 		{
+			int amount = e.Shift ? 1 : 5;
+
 			if (e.KeyCode == Keys.Right)
 			{
 				if (e.Control)
 				{
-					if (e.Shift)
-					{
-						this.Width += 1;
-					}
-					else
-					{
-						this.Left += 1;
-					}
+					this.Width += amount;
 				}
 				else
 				{
-					this.Left += 5;
+					this.Left += amount;
 				}
 			}
 			else if (e.KeyCode == Keys.Left)
 			{
 				if (e.Control)
 				{
-					if (e.Shift)
-					{
-						this.Width -= 1;
-					}
-					else
-					{
-						this.Left -= 1;
-					}
+					this.Width -= amount;
 				}
 				else
 				{
-					this.Left -= 5;
+					this.Left -= amount;
 				}
 			}
 			else if (e.KeyCode == Keys.Up)
 			{
 				if (e.Control)
 				{
-					if (e.Shift)
-					{
-						this.Height -= 1;
-					}
-					else
-					{
-						this.Top -= 1;
-					}
+					this.Height -= amount;
 				}
 				else
 				{
-					this.Top -= 5;
+					this.Top -= amount;
 				}
 			}
 			else if (e.KeyCode == Keys.Down)
 			{
 				if (e.Control)
 				{
-					if (e.Shift)
-					{
-						this.Height += 1;
-					}
-					else
-					{
-						this.Top += 1;
-					}
+					this.Height += amount;
 				}
 				else
 				{
-					this.Top += 5;
+					this.Top += amount;
 				}
 			}
 		}


### PR DESCRIPTION
The previous key combinations were confusing:

- Arrows - move by 5px
- Shift+Arrows - also move by 5px    (Shift has no meaning)
- Ctrl+Arrows - move by 1px          (Ctrl reduces step size to 1px)
- Ctrl+Shift+Arrows - resize by 1px  (If Ctrl reduces step size, what does Shift do?)

Each key modifier should have a specific purpose.  Even though the Ctrl modifier was common to reducing step size to 1px, since Shift is often used by other applications to reduce step size, it was chosen for this purpose, while Ctrl will indicate resize mode.  Thus:

- Arrows - move by 5px
- Shift+Arrows - move by 1px
- Ctrl+Arrows - resize by 5px
- Ctrl+Shift+Arrows - resize by 1px