### PR TITLE
Contrain ruler movement to horizontal or vertical while Shift is held.

### DIFF
--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -21,7 +21,6 @@ namespace Ruler
 		#region Fields
 
 		private ToolTip toolTip;
-		private Point offset;
 		private Rectangle mouseDownRect;
 		private int resizeBorderWidth;
 		private Point mouseDownFormLocation;
@@ -411,7 +410,6 @@ namespace Ruler
 				this.isMouseResizeCommand = true;
 			}
 
-			this.offset = new Point(Control.MousePosition.X - this.Location.X, Control.MousePosition.Y - this.Location.Y);
 			this.mouseDownPoint = Control.MousePosition;
 			this.mouseDownRect = this.ClientRectangle;
 			this.mouseDownFormLocation = this.Location;
@@ -459,7 +457,9 @@ namespace Ruler
 
 				if (e.Button == MouseButtons.Left)
 				{
-					this.Location = new Point(Control.MousePosition.X - this.offset.X, Control.MousePosition.Y - this.offset.Y);
+					int dx = Control.MousePosition.X - this.mouseDownPoint.X;
+					int dy = Control.MousePosition.Y - this.mouseDownPoint.Y;
+					this.Location = new Point(this.mouseDownFormLocation.X + dx, this.mouseDownFormLocation.Y + dy);
 				}
 			}
 

--- a/Source/Ruler/MainForm.cs
+++ b/Source/Ruler/MainForm.cs
@@ -457,9 +457,7 @@ namespace Ruler
 
 				if (e.Button == MouseButtons.Left)
 				{
-					int dx = Control.MousePosition.X - this.mouseDownPoint.X;
-					int dy = Control.MousePosition.Y - this.mouseDownPoint.Y;
-					this.Location = new Point(this.mouseDownFormLocation.X + dx, this.mouseDownFormLocation.Y + dy);
+					this.HandleMove();
 				}
 			}
 
@@ -494,6 +492,13 @@ namespace Ruler
 			}
 
 			base.OnKeyDown(e);
+		}
+
+		private void HandleMove()
+		{
+			int dx = Control.MousePosition.X - this.mouseDownPoint.X;
+			int dy = Control.MousePosition.Y - this.mouseDownPoint.Y;
+			this.Location = new Point(this.mouseDownFormLocation.X + dx, this.mouseDownFormLocation.Y + dy);
 		}
 
 		private void HandleMoveResizeKeystroke(KeyEventArgs e)


### PR DESCRIPTION
There are a couple of details in this feature. First, if done naively, a user will experience sudden jumps between snapping to horizontal or vertical axis when they move the mouse close to the starting mouse position. Second, it is difficult the mouse exactly horizontally or vertically. This adds noise to the first problem of moving close to the starting position.

I did the following:
- Don't constrain the movement at all in the beginning when the mouse is still very close to the starting position.
- Once the mouse has moved far enough, remember the direction and start constraining window movement.

Doing this seems to avoid any unexpected behavior during movement close to the starting position. Users can always change the direction by releasing Shift, moving the window, and then pressing Shift again.
 
Closes #42